### PR TITLE
Allow user to define textobj maps.

### DIFF
--- a/plugin/textobj/comment.vim
+++ b/plugin/textobj/comment.vim
@@ -16,13 +16,13 @@ endif
 call textobj#user#plugin('comment', {
      \   '-': {
      \     'select-a-function': 'textobj#comment#select_a',
-     \     'select-a': 'ac',
+     \     'select-a': get(g:, 'textobj_outer_comment_key', 'ac'),
      \     'select-i-function': 'textobj#comment#select_i',
-     \     'select-i': 'ic',
+     \     'select-i': get(g:, 'textobj_inner_comment_key', 'ic'),
      \   },
      \   'big': {
      \     'select-a-function': 'textobj#comment#select_big_a',
-     \     'select-a': 'aC',
+     \     'select-a': get(g:, 'textobj_outer_Comment_key', 'aC'),
      \   }
      \ })
 


### PR DESCRIPTION
If the user defines 'g:textobj_outer_comment_key' and friends, then they are used as the text object map. Otherwise the defaults are taken.
